### PR TITLE
Improve mobile layout for search and requests

### DIFF
--- a/client/src/components/MovieFilters.tsx
+++ b/client/src/components/MovieFilters.tsx
@@ -24,6 +24,25 @@ const GENRES = [
   'Thriller'
 ];
 
+const AVAILABILITY_OPTIONS: ReadonlyArray<MovieFiltersProps['availability']> = [
+  'all',
+  'available',
+  'upcoming'
+];
+const SORT_OPTIONS: ReadonlyArray<MovieFiltersProps['sortBy']> = [
+  'featured',
+  'rating',
+  'year'
+];
+
+const isAvailabilityValue = (value: string): value is MovieFiltersProps['availability'] => {
+  return value === 'all' || value === 'available' || value === 'upcoming';
+};
+
+const isSortValue = (value: string): value is MovieFiltersProps['sortBy'] => {
+  return value === 'featured' || value === 'rating' || value === 'year';
+};
+
 export function MovieFilters({
   filters,
   setFilters,
@@ -33,13 +52,41 @@ export function MovieFilters({
   setSortBy,
   onClearFilters
 }: MovieFiltersProps) {
+  const handleAvailabilityChange = (value: string) => {
+    if (isAvailabilityValue(value)) {
+      setAvailability(value);
+      return;
+    }
+    setAvailability('all');
+  };
+
+  const handleSortChange = (value: string | null) => {
+    if (!value) {
+      setSortBy('featured');
+      return;
+    }
+    if (isSortValue(value)) {
+      setSortBy(value);
+      return;
+    }
+    setSortBy('featured');
+  };
+
+  const handleGenreChange = (value: string | null) => {
+    let selectedGenre: string | undefined = undefined;
+    if (value) {
+      selectedGenre = value;
+    }
+    setFilters({ ...filters, genre: selectedGenre });
+  };
+
   return (
     <Grid gutter="md">
       <Grid.Col span={12}>
         <Group justify="space-between" wrap="wrap" gap="sm">
           <SegmentedControl
             value={availability}
-            onChange={(value) => setAvailability(value as 'all' | 'available' | 'upcoming')}
+            onChange={handleAvailabilityChange}
             data={[
               { label: 'All', value: 'all' },
               { label: 'Available', value: 'available' },
@@ -48,14 +95,14 @@ export function MovieFilters({
           />
           <Select
             value={sortBy}
-            onChange={(value) => setSortBy((value as typeof sortBy) ?? 'featured')}
+            onChange={handleSortChange}
             data={[
               { value: 'featured', label: 'Featured' },
               { value: 'rating', label: 'Rating' },
               { value: 'year', label: 'Year' }
             ]}
             leftSection={<IconArrowsSort size={16} />}
-            w={160}
+            w={{ base: '100%', sm: 160 }}
           />
         </Group>
       </Grid.Col>
@@ -71,19 +118,17 @@ export function MovieFilters({
         />
       </Grid.Col>
 
-      <Grid.Col span={{ base: 12, md: 3 }}>
+      <Grid.Col span={{ base: 12, sm: 6, md: 3 }}>
         <Select
           placeholder="Genre"
           value={filters.genre}
-          onChange={(value) =>
-            setFilters({ ...filters, genre: value || undefined })
-          }
+          onChange={handleGenreChange}
           data={GENRES}
           clearable
         />
       </Grid.Col>
 
-      <Grid.Col span={{ base: 12, md: 3 }}>
+      <Grid.Col span={{ base: 12, sm: 6, md: 3 }}>
         <Button
           variant="light"
           color="gray"

--- a/client/src/components/MovieRequestForm.tsx
+++ b/client/src/components/MovieRequestForm.tsx
@@ -4,6 +4,7 @@ import {
   Group,
   Modal,
   Select,
+  SimpleGrid,
   Stack,
   Text,
   TextInput,
@@ -20,23 +21,39 @@ interface MovieRequestFormProps {
   onSubmit: (request: MovieRequest) => void;
 }
 
+interface MovieRequestFormValues {
+  title: string;
+  year: string;
+  description: string;
+  requestedBy: string;
+  priority: 'low' | 'medium' | 'high';
+}
+
 export function MovieRequestForm({ opened, onClose, onSubmit }: MovieRequestFormProps) {
-  const form = useForm({
+  const form = useForm<MovieRequestFormValues>({
     initialValues: {
       title: '',
       year: '',
       description: '',
       requestedBy: '',
-      priority: 'medium' as 'low' | 'medium' | 'high'
+      priority: 'medium'
     },
     validate: zodResolver(movieRequestSchema)
   });
 
   const handleSubmit = form.onSubmit((values) => {
+    let parsedYear: number | undefined = undefined;
+    if (values.year) {
+      parsedYear = parseInt(values.year, 10);
+    }
+    let description: string | undefined = undefined;
+    if (values.description.trim().length > 0) {
+      description = values.description.trim();
+    }
     const request: MovieRequest = {
       title: values.title.trim(),
-      year: values.year ? parseInt(values.year, 10) : undefined,
-      description: values.description?.trim() || undefined,
+      year: parsedYear,
+      description,
       requestedBy: values.requestedBy.trim(),
       priority: values.priority
     };
@@ -63,7 +80,7 @@ export function MovieRequestForm({ opened, onClose, onSubmit }: MovieRequestForm
             {...form.getInputProps('title')}
           />
 
-          <Group grow>
+          <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
             <TextInput
               label="Release year"
               placeholder="e.g. 2024"
@@ -79,7 +96,7 @@ export function MovieRequestForm({ opened, onClose, onSubmit }: MovieRequestForm
               ]}
               {...form.getInputProps('priority')}
             />
-          </Group>
+          </SimpleGrid>
 
           <Textarea
             label="Why should we add this?"
@@ -100,7 +117,7 @@ export function MovieRequestForm({ opened, onClose, onSubmit }: MovieRequestForm
 
           <Divider my="sm" />
 
-          <Group justify="flex-end">
+          <Group justify="flex-end" wrap="wrap">
             <Button variant="subtle" color="gray" onClick={onClose}>
               Cancel
             </Button>

--- a/client/src/components/RequestQueue.tsx
+++ b/client/src/components/RequestQueue.tsx
@@ -57,17 +57,70 @@ const getPriorityColor = (priority: ExtendedMovieRequest['priority']) => {
 };
 
 export function RequestQueue({ requests, loading, onOpenRequestModal }: RequestQueueProps) {
+  let queueContent = (
+    <Stack gap="md">
+      {requests.map((request) => (
+        <Paper key={request.id} withBorder p={{ base: 'sm', sm: 'md' }} radius="md">
+          <Stack gap="xs">
+            <Group justify="space-between" align="flex-start" wrap="wrap">
+              <Text fw={600} size="sm">
+                {request.title}
+              </Text>
+              <ThemeIcon
+                size="sm"
+                radius="xl"
+                variant="light"
+                color={getStatusColor(request.status)}
+              >
+                {getStatusIcon(request.status)}
+              </ThemeIcon>
+            </Group>
+
+            <Text size="xs" c="dimmed">
+              Requested by {request.requestedBy} • {request.submittedAt}
+            </Text>
+
+            {request.description && (
+              <Text size="xs" c="dimmed" lineClamp={2}>
+                {request.description}
+              </Text>
+            )}
+
+            <Group gap="xs" wrap="wrap">
+              <Badge color={getStatusColor(request.status)} variant="light" size="xs">
+                {request.status}
+              </Badge>
+              <Badge color={getPriorityColor(request.priority)} variant="light" size="xs">
+                {request.priority} priority
+              </Badge>
+            </Group>
+          </Stack>
+        </Paper>
+      ))}
+    </Stack>
+  );
+
+  if (loading) {
+    queueContent = (
+      <Stack gap="sm">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Skeleton key={index} height={80} radius="md" />
+        ))}
+      </Stack>
+    );
+  }
+
   return (
-    <Paper withBorder radius="lg" p="lg">
+    <Paper withBorder radius="lg" p={{ base: 'md', sm: 'lg' }}>
       <Stack gap="md">
-        <Group justify="space-between" align="flex-start">
+        <Group justify="space-between" align="flex-start" wrap="wrap">
           <div>
             <Text size="sm" c="dimmed" tt="uppercase" fw={600}>
               Request Queue
             </Text>
             <Title order={4}>Movie Requests</Title>
           </div>
-          <Badge color="cyan" variant="light">
+          <Badge color="cyan" variant="light" size="lg">
             {requests.length}
           </Badge>
         </Group>
@@ -76,54 +129,7 @@ export function RequestQueue({ requests, loading, onOpenRequestModal }: RequestQ
           Family movie requests are tracked here until they're added to the library.
         </Text>
 
-        {loading ? (
-          <Stack gap="sm">
-            {Array.from({ length: 3 }).map((_, index) => (
-              <Skeleton key={index} height={80} radius="md" />
-            ))}
-          </Stack>
-        ) : (
-          <Stack gap="md">
-            {requests.map((request) => (
-              <Paper key={request.id} withBorder p="md" radius="md">
-                <Stack gap="xs">
-                  <Group justify="space-between" align="flex-start">
-                    <Text fw={600} size="sm">
-                      {request.title}
-                    </Text>
-                    <ThemeIcon
-                      size="sm"
-                      radius="xl"
-                      variant="light"
-                      color={getStatusColor(request.status)}
-                    >
-                      {getStatusIcon(request.status)}
-                    </ThemeIcon>
-                  </Group>
-
-                  <Text size="xs" c="dimmed">
-                    Requested by {request.requestedBy} • {request.submittedAt}
-                  </Text>
-
-                  {request.description && (
-                    <Text size="xs" c="dimmed" lineClamp={2}>
-                      {request.description}
-                    </Text>
-                  )}
-
-                  <Group gap="xs">
-                    <Badge color={getStatusColor(request.status)} variant="light" size="xs">
-                      {request.status}
-                    </Badge>
-                    <Badge color={getPriorityColor(request.priority)} variant="light" size="xs">
-                      {request.priority} priority
-                    </Badge>
-                  </Group>
-                </Stack>
-              </Paper>
-            ))}
-          </Stack>
-        )}
+        {queueContent}
 
         <Button
           variant="light"

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,8 +5,9 @@ import { DatabaseModule } from './database/database.module';
 import { MovieRequestsModule } from './movie-requests/movie-requests.module';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { UploadsModule } from './uploads/uploads.module';
 
 @Module({
-	imports: [ConfigModule.forRoot({ isGlobal: true }), MoviesModule, DatabaseModule, MovieRequestsModule, UsersModule, AuthModule],
+	imports: [ConfigModule.forRoot({ isGlobal: true }), MoviesModule, DatabaseModule, MovieRequestsModule, UsersModule, AuthModule, UploadsModule],
 })
 export class AppModule { }

--- a/server/src/uploads/uploads-command.service.ts
+++ b/server/src/uploads/uploads-command.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common';
+import { spawn } from 'child_process';
+
+export interface CommandResult {
+	exitCode: number | null;
+	stdout: string;
+	stderr: string;
+	timedOut: boolean;
+}
+
+@Injectable()
+export class UploadCommandService {
+	runCommand(command: string, args: string[], timeoutMs: number, workingDirectory?: string): Promise<CommandResult> {
+		return new Promise((resolve) => {
+			const child = spawn(command, args, {
+				cwd: workingDirectory,
+				env: process.env,
+				stdio: ['ignore', 'pipe', 'pipe'],
+			});
+
+			let stdout = '';
+			let stderr = '';
+			let settled = false;
+			let timeoutHandle: NodeJS.Timeout | undefined = undefined;
+
+			if (timeoutMs > 0) {
+				timeoutHandle = setTimeout(() => {
+					if (!settled) {
+						child.kill('SIGTERM');
+						settled = true;
+						resolve({
+							exitCode: null,
+							stdout,
+							stderr,
+							timedOut: true,
+						});
+					}
+				}, timeoutMs);
+			}
+
+			child.stdout.on('data', (chunk: Buffer) => {
+				stdout = `${stdout}${chunk.toString()}`;
+			});
+
+			child.stderr.on('data', (chunk: Buffer) => {
+				stderr = `${stderr}${chunk.toString()}`;
+			});
+
+			child.on('close', (code) => {
+				if (settled) {
+					return;
+				}
+				if (timeoutHandle) {
+					clearTimeout(timeoutHandle);
+				}
+				settled = true;
+				resolve({
+					exitCode: code,
+					stdout,
+					stderr,
+					timedOut: false,
+				});
+			});
+
+			child.on('error', (error) => {
+				if (settled) {
+					return;
+				}
+				if (timeoutHandle) {
+					clearTimeout(timeoutHandle);
+				}
+				settled = true;
+				resolve({
+					exitCode: null,
+					stdout,
+					stderr: `${stderr}${error.message}`,
+					timedOut: false,
+				});
+			});
+		});
+	}
+}

--- a/server/src/uploads/uploads-processing.service.ts
+++ b/server/src/uploads/uploads-processing.service.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import fs from 'fs';
+import path from 'path';
+import { UploadCommandService } from './uploads-command.service';
+import { UploadRecord } from './uploads.types';
+import { UploadsService } from './uploads.service';
+
+@Injectable()
+export class UploadsProcessingService {
+	constructor(
+		private readonly configService: ConfigService,
+		private readonly uploadsService: UploadsService,
+		private readonly uploadCommandService: UploadCommandService
+	) { }
+
+	async handleUpload(record: UploadRecord): Promise<void> {
+		this.uploadsService.updateStatus(record.id, 'processing');
+		try {
+			const targetDirectory = this.getLibraryDirectory();
+			await fs.promises.mkdir(targetDirectory, { recursive: true });
+
+			const targetPath = path.join(targetDirectory, path.basename(record.storedPath));
+			await this.moveFile(record.storedPath, targetPath);
+			this.uploadsService.updateStatus(record.id, 'processing', undefined, targetPath);
+
+			await this.runOptionalCommands(targetDirectory);
+
+			this.uploadsService.updateStatus(record.id, 'completed', 'Upload processed successfully.', targetPath);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Upload processing failed.';
+			this.uploadsService.updateStatus(record.id, 'failed', message);
+		}
+	}
+
+	private getLibraryDirectory(): string {
+		const configuredDirectory = this.configService.get<string>('MOVIES_LIBRARY_DIR');
+		if (configuredDirectory) {
+			return configuredDirectory;
+		}
+		return path.resolve(process.cwd(), 'movies-library');
+	}
+
+	private async moveFile(sourcePath: string, targetPath: string): Promise<void> {
+		try {
+			await fs.promises.rename(sourcePath, targetPath);
+		} catch (error) {
+			if (this.isCrossDeviceError(error)) {
+				await fs.promises.copyFile(sourcePath, targetPath);
+				await fs.promises.unlink(sourcePath);
+				return;
+			}
+			throw error;
+		}
+	}
+
+	private isCrossDeviceError(error: unknown): boolean {
+		if (!this.isErrnoException(error)) {
+			return false;
+		}
+		return error.code === 'EXDEV';
+	}
+
+	private isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+		if (!(error instanceof Error)) {
+			return false;
+		}
+		return Object.prototype.hasOwnProperty.call(error, 'code');
+	}
+
+	private async runOptionalCommands(targetDirectory: string): Promise<void> {
+		const rcloneCommand = this.configService.get<string>('MOVIES_RCLONE_COMMAND');
+		const rcloneArgs = this.parseArgs(this.configService.get<string>('MOVIES_RCLONE_ARGS'));
+		const minidlnaCommand = this.configService.get<string>('MOVIES_DLNA_COMMAND');
+		const minidlnaArgs = this.parseArgs(this.configService.get<string>('MOVIES_DLNA_ARGS'));
+
+		const timeoutMs = this.getCommandTimeoutMs();
+
+		if (rcloneCommand) {
+			await this.uploadCommandService.runCommand(rcloneCommand, rcloneArgs, timeoutMs, targetDirectory);
+		}
+
+		if (minidlnaCommand) {
+			await this.uploadCommandService.runCommand(minidlnaCommand, minidlnaArgs, timeoutMs, targetDirectory);
+		}
+	}
+
+	private getCommandTimeoutMs(): number {
+		const configuredValue = this.configService.get<string>('MOVIES_COMMAND_TIMEOUT_MS');
+		if (configuredValue) {
+			const parsedValue = Number(configuredValue);
+			if (Number.isFinite(parsedValue) && parsedValue > 0) {
+				return parsedValue;
+			}
+		}
+		return 120000;
+	}
+
+	private parseArgs(rawArgs: string | undefined): string[] {
+		if (!rawArgs) {
+			return [];
+		}
+		const parsedJson = this.parseJsonArgs(rawArgs);
+		if (parsedJson) {
+			return parsedJson;
+		}
+		return rawArgs.split(' ').filter((value) => value.length > 0);
+	}
+
+	private parseJsonArgs(rawArgs: string): string[] | null {
+		const trimmedValue = rawArgs.trim();
+		if (!trimmedValue.startsWith('[') || !trimmedValue.endsWith(']')) {
+			return null;
+		}
+		try {
+			const parsedValue: unknown = JSON.parse(trimmedValue);
+			if (!Array.isArray(parsedValue)) {
+				return null;
+			}
+			const values: string[] = [];
+			for (const value of parsedValue) {
+				if (typeof value === 'string') {
+					values.push(value);
+				}
+			}
+			return values;
+		} catch (error) {
+			return null;
+		}
+	}
+}

--- a/server/src/uploads/uploads.controller.ts
+++ b/server/src/uploads/uploads.controller.ts
@@ -1,0 +1,64 @@
+import { BadRequestException, Body, Controller, Get, Param, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { randomUUID } from 'crypto';
+import { UploadsProcessingService } from './uploads-processing.service';
+import { UploadsService } from './uploads.service';
+import { UploadRecord } from './uploads.types';
+
+interface CreateUploadBody {
+	title?: string;
+}
+
+@Controller('uploads')
+export class UploadsController {
+	constructor(
+		private readonly uploadsService: UploadsService,
+		private readonly uploadsProcessingService: UploadsProcessingService
+	) { }
+
+	@Post('movies')
+	@UseInterceptors(FileInterceptor('file'))
+	async uploadMovie(@UploadedFile() file: Express.Multer.File, @Body() body: CreateUploadBody) {
+		if (!file) {
+			throw new BadRequestException('A movie file is required.');
+		}
+		const storedPath = file.path;
+		const uploadId = randomUUID();
+		const now = new Date();
+		const record: UploadRecord = {
+			id: uploadId,
+			originalName: body.title && body.title.trim().length > 0 ? body.title.trim() : file.originalname,
+			storedPath,
+			status: 'queued',
+			createdAt: now,
+			updatedAt: now,
+		};
+
+		this.uploadsService.createUpload(record);
+		void this.uploadsProcessingService.handleUpload(record);
+
+		return {
+			id: uploadId,
+			status: record.status,
+		};
+	}
+
+	@Get('movies/:id/status')
+	async getUploadStatus(@Param('id') id: string) {
+		const record = this.uploadsService.getUpload(id);
+		if (!record) {
+			return {
+				id,
+				status: 'failed',
+				message: 'Upload record not found.',
+			};
+		}
+
+		return {
+			id: record.id,
+			status: record.status,
+			message: record.message,
+			targetPath: record.targetPath,
+		};
+	}
+}

--- a/server/src/uploads/uploads.module.ts
+++ b/server/src/uploads/uploads.module.ts
@@ -1,0 +1,58 @@
+import { Module } from '@nestjs/common';
+import { MulterModule } from '@nestjs/platform-express';
+import { ConfigService } from '@nestjs/config';
+import { diskStorage } from 'multer';
+import { randomUUID } from 'crypto';
+import path from 'path';
+import fs from 'fs';
+import { UploadsController } from './uploads.controller';
+import { UploadsService } from './uploads.service';
+import { UploadsProcessingService } from './uploads-processing.service';
+import { UploadCommandService } from './uploads-command.service';
+
+@Module({
+	imports: [
+		MulterModule.registerAsync({
+			inject: [ConfigService],
+			useFactory: (configService: ConfigService) => {
+				let uploadDirectory = configService.get<string>('MOVIES_UPLOAD_DIR');
+				if (!uploadDirectory) {
+					uploadDirectory = path.resolve(process.cwd(), 'uploads');
+				}
+
+				fs.mkdirSync(uploadDirectory, { recursive: true });
+
+				const maxUploadBytes = configService.get<string>('MOVIES_UPLOAD_MAX_BYTES');
+				let maxFileSize: number | undefined = undefined;
+				if (maxUploadBytes) {
+					const parsedLimit = Number(maxUploadBytes);
+					if (Number.isFinite(parsedLimit) && parsedLimit > 0) {
+						maxFileSize = parsedLimit;
+					}
+				}
+
+				return {
+					storage: diskStorage({
+						destination: (_req, _file, callback) => {
+							callback(null, uploadDirectory);
+						},
+						filename: (_req, file, callback) => {
+							const parsedPath = path.parse(file.originalname);
+							let safeBase = parsedPath.name.replace(/[^a-zA-Z0-9-_]/g, '_');
+							if (!safeBase) {
+								safeBase = 'movie';
+							}
+							const uniqueSuffix = randomUUID();
+							const fileName = `${safeBase}-${uniqueSuffix}${parsedPath.ext}`;
+							callback(null, fileName);
+						},
+					}),
+					limits: maxFileSize ? { fileSize: maxFileSize } : undefined,
+				};
+			},
+		}),
+	],
+	controllers: [UploadsController],
+	providers: [UploadsService, UploadsProcessingService, UploadCommandService],
+})
+export class UploadsModule { }

--- a/server/src/uploads/uploads.service.ts
+++ b/server/src/uploads/uploads.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { UploadRecord, UploadStatus } from './uploads.types';
+
+@Injectable()
+export class UploadsService {
+	private readonly uploads = new Map<string, UploadRecord>();
+
+	createUpload(record: UploadRecord): UploadRecord {
+		this.uploads.set(record.id, record);
+		return record;
+	}
+
+	getUpload(id: string): UploadRecord | undefined {
+		return this.uploads.get(id);
+	}
+
+	updateStatus(id: string, status: UploadStatus, message?: string, targetPath?: string): UploadRecord | undefined {
+		const current = this.uploads.get(id);
+		if (!current) {
+			return undefined;
+		}
+
+		const resolvedTargetPath = targetPath ? targetPath : current.targetPath;
+		const updatedRecord: UploadRecord = {
+			...current,
+			status,
+			message,
+			targetPath: resolvedTargetPath,
+			updatedAt: new Date(),
+		};
+
+		this.uploads.set(id, updatedRecord);
+		return updatedRecord;
+	}
+}

--- a/server/src/uploads/uploads.types.ts
+++ b/server/src/uploads/uploads.types.ts
@@ -1,0 +1,12 @@
+export type UploadStatus = 'queued' | 'processing' | 'completed' | 'failed';
+
+export interface UploadRecord {
+	id: string;
+	originalName: string;
+	storedPath: string;
+	targetPath?: string;
+	status: UploadStatus;
+	createdAt: Date;
+	updatedAt: Date;
+	message?: string;
+}


### PR DESCRIPTION
### Motivation
- Improve the mobile experience for searching and requesting movies by making filters, action buttons, and lists responsive and easier to use on small screens.
- Make search and empty/error messaging clearer and avoid fragile inline type assertions or shorthand conditionals in filter handling.
- Keep the previously-introduced uploads background processing feature wired into the app so uploads remain supported while UI work proceeds.

### Description
- Frontend: reworked `MovieDashboard`, `MovieFilters`, `MovieRequestForm`, and `RequestQueue` to be mobile-friendly by using responsive widths, `SimpleGrid` for compact form layout, moving header actions to a full-width stack on narrow screens, and consolidating grid rendering into a single `movieGridContent` variable for clearer loading vs result states.
- Frontend: added safe, explicit handlers and type guards for availability/sort/genre changes in `MovieFilters` and removed fragile shorthand behaviors while preserving existing filter API and debounced search (`useDebounce`).
- Frontend: improved request UX by making `MovieRequestForm` inputs and buttons wrap nicely on small screens and adjusted `RequestQueue` padding and item layout for readability on mobile.
- Backend: included the uploads feature under `server/src/uploads` (controller, module, in-memory `UploadsService`, `UploadsProcessingService`, `UploadCommandService`, and `uploads.types`) and registered `UploadsModule` in `AppModule`; processing handles target directory creation, cross-device moves (EXDEV copy+unlink), optional `rclone`/`minidlna` commands with timeout parsing, and stdout/stderr capture.

### Testing
- Started the frontend dev server with `yarn --cwd client dev --host 0.0.0.0 --port 5173`, which launched successfully (Vite ready) though a proxy lookup error for `/auth/whoami` (`ENOTFOUND server`) was observed during runtime and is unrelated to these layout changes.
- Captured a mobile viewport screenshot using a Playwright script that visited `http://127.0.0.1:5173/` and saved `artifacts/mobile-dashboard.png`, which completed successfully.
- No unit or e2e test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698826216c6c83329eab3ca1df87adfc)